### PR TITLE
feat:add new variables to acm module

### DIFF
--- a/examples/generate-certificate-dns/example.tf
+++ b/examples/generate-certificate-dns/example.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 locals {
-  domain = "clouddrove.com"
+  domain = "ld.clouddrove.ca"
 }
 
 ##-----------------------------------------------------------------------------
@@ -12,8 +12,11 @@ locals {
 module "acm" {
   source = "./../../"
 
-  name                      = "certificate"
-  environment               = "test"
-  domain_name               = "clouddrove.com"
-  subject_alternative_names = ["www.${local.domain}", "*.${local.domain}"]
+  name                         = "certificate"
+  environment                  = "test"
+  enable_dns_validation        = true
+  domain_name                  = "ld.clouddrove.ca"
+  subject_alternative_names    = ["www.${local.domain}", "*.${local.domain}"]
+  key_algorithm                = "RSA_2048"
+  transparency_logging_enabled = false
 }

--- a/examples/generate-certificate-dns/outputs.tf
+++ b/examples/generate-certificate-dns/outputs.tf
@@ -23,4 +23,7 @@ output "validation_route53_record_fqdns" {
   description = "List of FQDNs built using the zone domain and name."
 }
 
-
+output "certificate_transparency_logging_preference" {
+  value       = module.acm
+  description = "Certificate transparency logging preference."
+}

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,7 @@ resource "aws_acm_certificate" "cert" {
   domain_name               = var.domain_name
   validation_method         = var.validation_method
   subject_alternative_names = var.subject_alternative_names
+  key_algorithm             = var.key_algorithm
   tags                      = module.labels.tags
 
   dynamic "validation_option" {
@@ -56,6 +57,14 @@ resource "aws_acm_certificate" "cert" {
     }
   }
 
+  dynamic "options" {
+    for_each = var.transparency_logging_enabled != null ? [1] : []
+    content {
+      certificate_transparency_logging_preference = var.transparency_logging_enabled ? "ENABLED" : "DISABLED"
+    }
+  }
+
+
   lifecycle {
     create_before_destroy = true
   }
@@ -65,7 +74,7 @@ resource "aws_acm_certificate" "cert" {
 ## Most commonly, this resource is used together with aws_route53_record and aws_acm_certificate to request a DNS validated certificate, deploy the required validation records and wait for validation to complete.
 ##----------------------------------------------------------------------------------
 resource "aws_acm_certificate_validation" "cert" {
-  count                   = var.enable && var.validate_certificate ? 1 : 0
+  count                   = var.enable && var.enable_dns_validation && var.validate_certificate ? 1 : 0
   certificate_arn         = join("", aws_acm_certificate.cert[*].arn)
   validation_record_fqdns = flatten([aws_route53_record.default[*].fqdn, var.validation_record_fqdns])
 
@@ -84,13 +93,13 @@ data "aws_route53_zone" "default" {
 ## A Route 53 record contains authoritative DNS information for a specified DNS name. DNS records are most commonly used to map a name to an IP Address..
 ##----------------------------------------------------------------------------------
 resource "aws_route53_record" "default" {
-  for_each = {
+  for_each = var.enable_dns_validation ? {
     for record in aws_acm_certificate.cert[0].domain_validation_options[*] : record.domain_name => {
       name   = record.resource_record_name
       record = record.resource_record_value
       type   = record.resource_record_type
     }
-  }
+  } : {}
 
   allow_overwrite = var.allow_overwrite
   name            = each.value.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,8 +26,12 @@ output "acm_certificate_status" {
   description = "Status of the certificate."
 }
 
-
 output "validation_route53_record_fqdns" {
   value       = [for record in aws_route53_record.default : record.fqdn]
   description = "List of FQDNs built using the zone domain and name."
+}
+
+output "certificate_transparency_logging_preference" {
+  value       = try(aws_acm_certificate.cert[0].options[0].certificate_transparency_logging_preference, null)
+  description = "Certificate transparency logging preference."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -128,4 +128,15 @@ variable "private_zone" {
   description = "Used with name field to get a private Hosted Zone."
 }
 
+variable "key_algorithm" {
+  type        = string
+  default     = null
+  description = "used to generate the public/private key pair for the certificate. Valid values: RSA_2048, RSA_4096, EC_prime256v1, EC_secp384r1, EC_secp521r1."
+}
+
+variable "transparency_logging_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether to enable certificate transparency logging. Defaults to true. Set to false to disable."
+}
 


### PR DESCRIPTION
## what
* Added support for the key_algorithm argument in the aws_acm_certificate resource.
* Introduced a conditional options block to configure certificate_transparency_logging_preference.
* Use bullet points to be concise and to the point.

## why
* Allows users to specify the cryptographic algorithm used for ACM certificates.
* Enables/disables certificate transparency logging as required by security policies or compliance.
* Keeps the module up to date with the latest AWS features and Terraform provider enhancements.

## references
* [Terraform AWS Provider docs – aws_acm_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate)